### PR TITLE
Repo can destroy objects

### DIFF
--- a/services/repository.js
+++ b/services/repository.js
@@ -15,6 +15,10 @@ export default class Repository {
     return this._objects[id];
   }
 
+  destroy(obj) {
+    delete this._objects[obj.id];
+  }
+
   clear() {
     this._objects = [];
   }

--- a/spec/services/repository.spec.js
+++ b/spec/services/repository.spec.js
@@ -59,4 +59,19 @@ describe('Repository', () => {
 
     expect(repo.count).toEqual(0);
   });
+
+  test('can destroy object', () => {
+    const foo = new Foo('a');
+    const foo2 = new Foo('b');
+
+    repo.insert(foo);
+    repo.insert(foo2);
+
+    repo.destroy(foo);
+
+    expect(repo.count).toEqual(1);
+
+    expect(repo.find('a')).toBeUndefined();
+    expect(repo.find('b')).toBe(foo2);
+  });
 });


### PR DESCRIPTION
<!-- Please add the issue number(s) this PR closes -->
<!-- ex: closes #12 -->
## Description
Repo can destroy objects so we can remove games and inactive players from memory

## Context
Without destroying them, too much memory will be taken up

## How Has This Been Tested?
Unit tests added to the Repository class

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Review the following and place an 'x' in all relevant boxes -->
- [x] My code follows the code style of this project (linter passes)
- [x] My change requires a change to the documentation
  - [ ] I have made these changes
  - [x] These changes need to be made
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Miscellaneous:
<!-- Add any extra information here -->
